### PR TITLE
Disable sandboxing

### DIFF
--- a/harbour-searchnemo.desktop
+++ b/harbour-searchnemo.desktop
@@ -15,6 +15,4 @@ Comment[de]=Text- und Dateisuchmaschine
 Comment[ru]=Инструмент поиска текста и файлов
 
 [X-Sailjail]
-OrganizationName=searchnemo
-ApplicationName=searchnemo
-Permissions=UserDirs;RemovableMedia;Calendar;Contacts;Messages;Accounts;Email;Privileged;Synchronization
+Sandboxing=Disabled


### PR DESCRIPTION
This allows one to see /usr/share/harbour* dirs where most apps have their QML code which are a great examples for developing on-device, like a local copy of stackoverflow, pretty sure there isn't a sailjail permission for that